### PR TITLE
.gitignore: Ignore book output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Ignore book output
+book


### PR DESCRIPTION
Prevents cluttering of git tracked files due to generated output.